### PR TITLE
Fix Build for NixOS 22.05 (and beyond)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,6 @@
-{ buildPythonApplication
+{ python3Packages
 , fetchFromGitHub
 , drawio
-, pandocfilters
 , xvfb-run
 , runtimeShell
 , writeScriptBin
@@ -32,7 +31,7 @@ let
   '';
 in
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "pandoc-drawio-filter";
   version = "1.1";
 
@@ -40,7 +39,7 @@ buildPythonApplication {
 
   propagatedBuildInputs = [
     wrappedDrawio
-    pandocfilters
+    python3Packages.pandocfilters
   ];
 
   # Activate this in a local CI that pins black. Every version difference of

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bb06e1a157f659f12c4d73255178c84e2666c71",
-        "sha256": "0g4q7sz2sb5yab1k4zddma0ilxiq15k4ya6z6sjz6pqk4h1w1v6b",
+        "rev": "8f73de28e63988da02426ebb17209e3ae07f103b",
+        "sha256": "1mvq8wxdns802b1gvjvalbvdsp3xjgm370bimdd93mwpspz0250p",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7bb06e1a157f659f12c4d73255178c84e2666c71.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8f73de28e63988da02426ebb17209e3ae07f103b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 


### PR DESCRIPTION
At some point `buildPythonApplication` went away and the way to build Python applications is to directly reference `python3Packages`.

While I was here, I also updated the nixpkgs pin to recent `nixpkgs-unstable`.