### PR TITLE
Publish to PyPi

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,0 +1,29 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository
+      - uses: actions/checkout@v2
+      # Set up a Python environment
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      # Install the project dependencies
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      # Generate the requirements.txt file
+      - run: pip freeze > requirements.txt
+      # Install twine
+      - run: pip install twine
+      # Build and publish the package
+      - run: |
+          python setup.py sdist bdist_wheel
+          python -m twine upload --skip-existing dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,164 @@
 result
 result-*
 *.pdf
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/pandoc_drawio_filter/pandoc_drawio_filter.py
+++ b/pandoc_drawio_filter/pandoc_drawio_filter.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import platform
 
 from pandocfilters import toJSONFilter, Image
 
@@ -27,8 +28,15 @@ def drawio(key, value, format_, _):
         if src_extension == ".drawio":
             pdf_name = f"{src_basename}.pdf"
             if modification_time(pdf_name) < modification_time(src):
+                # Set the drawio binary based on the operating system
+                if platform.system() == "Darwin":
+                    drawio_binary = "/Applications/draw.io.app/Contents/MacOS/draw.io"
+                elif platform.system() == "Windows":
+                    drawio_binary = "drawio.exe"
+                else:
+                    drawio_binary = "drawio"
                 cmd_line = [
-                    "drawio",
+                    drawio_binary,
                     "--crop",
                     "-f",
                     "pdf",

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     url="https://github.com/tfc/pandoc-drawio-filter",
     description="Pandoc filter that converts *.drawio images to PDF",
     packages=find_packages(),
+    install_requires=['pandocfilters==1.5.0'],
     entry_points={
         "console_scripts": [
             "pandoc-drawio = pandoc_drawio_filter.pandoc_drawio_filter:main"


### PR DESCRIPTION
Create a setup for the module, defer the requirements.txt generation to the github action, create an action that publishes to pypi triggered on tags.

I'm running this on OSX, I've tested locally with 

```bash
python setup.py sdist bdist_wheel
pip install --force-reinstall dist/pandoc_drawio_filter-1.0-py3-none-any.whl
```

I'm unable to test the action, as its based on a tag, you'll need to test this yourself.  

I had to update the drawio function as it was expecting a binary called drawio to be available.  On OSX I installed the drawio desktop using homebrew, this placed the binary in /Applications/draw.io.app/Contents/MacOS/ and named it draw.io, so I included support through platform.system for setting the appropriately binary.  Confirmed OSX installer from drawio directly also places binary in /Applications folder.

Alternative solution would be for user to softlink binary to drawio.  Up to yourself if you wish to accept this part of the MR.

Thanks,
Damian.